### PR TITLE
Add windows info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ The following platforms are currently supported:
 
 * Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory.
 
-For example:
+  For example:
 
-    export GRAALVM_HOME=/opt/graalvm-svm-darwin-20.1.0-ea+28
+      export GRAALVM_HOME=/opt/graalvm-svm-darwin-20.1.0-ea+28
 
 * Set `JAVA_HOME` to point to the GraalVM installation directory
 
-For example:
+  For example:
 
-    export JAVA_HOME=$GRAALVM_HOME
+      export JAVA_HOME=$GRAALVM_HOME
 
 #### Linux and Android
 
@@ -36,21 +36,22 @@ For example:
 
 * Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory.
 
-For example:
+  For example:
 
-    export GRAALVM_HOME=/opt/graalvm-svm-linux-20.1.0-ea+28
+      export GRAALVM_HOME=/opt/graalvm-svm-linux-20.1.0-ea+28
 
 * Set `JAVA_HOME` to point to the GraalVM installation directory
 
-For example:
+  For example:
 
-    export JAVA_HOME=$GRAALVM_HOME
+      export JAVA_HOME=$GRAALVM_HOME
 
 #### Windows
 
 * Download the latest development version of GraalVM: https://github.com/graalvm/graalvm-ce-dev-builds/releases by choosing `graalvm-ce-java11-windows-amd64-20.2.0-dev.zip` from the list of assets and unzip it to a preferred location on your system.
 
 * Make sure you have installed Visual Studio 2019 with the following components:
+  - Choose the English Language Pack
   - C++/CLI support for v142 build tools (14.25 or later)
   - MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.25 or later)
   - Windows Universal CRT SDK
@@ -61,15 +62,19 @@ from the start menu.
 
 * Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory.
 
-For example:
+  For example:
 
-    set GRAALVM_HOME=C:\tools\graalvm-ce-java11-20.2.0-dev
+      set GRAALVM_HOME=C:\tools\graalvm-ce-java11-20.2.0-dev
 
+  Install native-image by running:
+
+      %GRAALVM_HOME%\bin\gu install native-image
+  
 * Set `JAVA_HOME` to point to the GraalVM installation directory
 
-For example:
+  For example:
 
-    set JAVA_HOME=%GRAALVM_HOME%
+      set JAVA_HOME=%GRAALVM_HOME%
 
 ### Build using Maven
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Java and JavaFX samples to run with GraalVM and the Gluon Client plugins for [Maven](https://github.com/gluonhq/client-maven-plugin/).
 
-For now only Linux, Mac OS X, iOS and Android platforms are supported. 
+The following platforms are currently supported:
+
+* Linux
+* Mac OS X
+* Windows
+* iOS
+* Android
 
 ## Build and run the samples
 
@@ -10,7 +16,7 @@ For now only Linux, Mac OS X, iOS and Android platforms are supported.
 
 #### Mac OS X and iOS
 
-* Download this version of Graal VM: https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-darwin-20.1.0-ea+28.zip and unpack it like you would any other JDK. (e.g. in `/opt`)
+* Download this version of GraalVM: https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-darwin-20.1.0-ea+28.zip and unpack it like you would any other JDK. (e.g. in `/opt`)
 
 * Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory.
 
@@ -26,7 +32,7 @@ For example:
 
 #### Linux and Android
 
-* Download this version of Graal VM: https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-linux-20.1.0-ea+28.zip and unpack it like you would any other JDK. (e.g. in `/opt`)
+* Download this version of GraalVM: https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-linux-20.1.0-ea+28.zip and unpack it like you would any other JDK. (e.g. in `/opt`)
 
 * Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory.
 
@@ -40,11 +46,36 @@ For example:
 
     export JAVA_HOME=$GRAALVM_HOME
 
+#### Windows
+
+* Download the latest development version of GraalVM: https://github.com/graalvm/graalvm-ce-dev-builds/releases by choosing `graalvm-ce-java11-windows-amd64-20.2.0-dev.zip` from the list of assets and unzip it to a preferred location on your system.
+
+* Make sure you have installed Visual Studio 2019 with the following components:
+  - C++/CLI support for v142 build tools (14.25 or later)
+  - MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.25 or later)
+  - Windows Universal CRT SDK
+  - Windows 10 SDK (10.0.19041.0 or later)
+
+* Run the maven commands mentioned below in a `x64 Native Tools Command Prompt for VS 2019`. This command prompt can be accessed
+from the start menu.
+
+* Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory.
+
+For example:
+
+    set GRAALVM_HOME=C:\tools\graalvm-ce-java11-20.2.0-dev
+
+* Set `JAVA_HOME` to point to the GraalVM installation directory
+
+For example:
+
+    set JAVA_HOME=%GRAALVM_HOME%
+
 ### Build using Maven
 
 #### HelloWorld, HelloFX, HelloFXML and HelloGluon samples
 
-The following goals apply to Linux and Mac OS X.
+The following goals apply to Linux, Mac OS X and Windows.
 
 To build the native image:
 


### PR DESCRIPTION
Adds information on how to build and run the client samples on the windows platform.